### PR TITLE
Avoid save race condition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smol"
-version = "0.3.0"
+version = "0.4.0"
 description = "Core services for smol.io url shortener"
 authors = ["Demetrius Shargani <developerdemetri@gmail.com>"]
 

--- a/smol/shorten.py
+++ b/smol/shorten.py
@@ -72,5 +72,5 @@ class Shortener:
 
         target_id = self._generate_id()
         new_link = Link(id=target_id, target=self.target)
-        new_link.save()
+        new_link.save(condition=Link.id.does_not_exist())
         return new_link

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,7 +2,7 @@ from json import dumps
 from os import environ
 from unittest import TestCase
 
-from flexmock import flexmock_teardown
+from flexmock import flexmock, flexmock_teardown
 
 from smol.link import Link
 
@@ -75,6 +75,11 @@ class TestBase(TestCase):
         environ["AWS_SECRET_ACCESS_KEY"] = "mock"
         environ["CAPTCHA_KEY"] = "mock"
         environ["SAFE_BROWSING_KEY"] = "mock"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_conn = flexmock()
+        flexmock(Link).should_receive("_get_connection").and_return(self.mock_conn)
 
     def tearDown(self) -> None:
         flexmock_teardown()


### PR DESCRIPTION
Avoid the chance that 2 new Links get the same ID at the same time and 1 gets overwritten